### PR TITLE
IMP add setup.py for pyspark 1.6.0

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -36,6 +36,44 @@ Public classes:
       Finer-grained cache persistence levels.
 
 """
+import logging
+import os
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_spark_version():
+    """
+    Detect version of Spark located under SPARK_HOME.
+    """
+    spark_home = os.environ.get('SPARK_HOME')
+    if not spark_home:
+        logger.warning("Environment variable SPARK_HOME is not set")
+        return
+
+    libs_path = os.path.join(os.environ['SPARK_HOME'], 'lib')
+    for jar_file in os.listdir(libs_path):
+        if jar_file.startswith('spark-assembly'):
+            try:
+                return re.match('spark-assembly-([^-]+)', jar_file).group(1)
+            except IndexError:
+                logger.warning("Can't detect Spark version by the assembly file")
+
+    logger.warning("Can't find file with Spark version")
+
+
+installed_version = get_spark_version()
+__version__ = '1.6.0'
+
+
+if installed_version is None:
+    logger.warning("Spark is not installed on this machine")
+elif installed_version != __version__:
+    logger.warning("Incompatible versions of PySpark (%s) and Spark (%s)",
+                   __version__, installed_version)
+
 
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,51 @@
+import re
+
+from setuptools import setup
+
+
+def read_version(path_to_py_module):
+    with open(path_to_py_module) as py_module:
+        match = re.search('__version__ = \'([\d.]+)\'', py_module.read())
+        if match:
+            return match.group(1)
+        raise RuntimeError('Can not find the package version in {}'.format(path_to_py_module))
+
+
+setup(
+    name='tubular-pyspark',
+    version=read_version('pyspark/__init__.py'),
+    packages=[
+        'pyspark',
+        'pyspark.mllib',
+        'pyspark.ml',
+        'pyspark.sql',
+        'pyspark.streaming',
+    ],
+    install_requires=[
+        'py4j==0.9',
+    ],
+    extras_require={
+        'ml': ['numpy>=1.7'],
+        'sql': ['pandas'],
+    },
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Topic :: Software Development',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'License :: OSI Approved :: Apache Software License',
+    ],
+    description='Apache Spark Python API',
+    keywords='spark pyspark',
+    author='Spark Developers',
+    author_email='dev@spark.apache.org',
+    url='https://github.com/apache/spark/tree/master/python',
+    license='http://www.apache.org/licenses/LICENSE-2.0',
+)


### PR DESCRIPTION
Make PySpark friendly to the Python ecosystem.
Now, we consider it as a package with dependencies on py4j.
Changes were tested manually.